### PR TITLE
Move certain resources to global

### DIFF
--- a/pmm/aws_iam_roles_policies.tf
+++ b/pmm/aws_iam_roles_policies.tf
@@ -1,0 +1,57 @@
+# These roles and policies should be created first as "global" resources
+# which are then imported and used by everyone. They will not be destroyed
+# when someone executed 'terraform destroy' from within the pmmdemo directory
+
+resource "aws_iam_user" "rds_user" {
+  name = "pmm-demo-rds-user"
+}
+
+resource "aws_iam_policy" "pmmdemo-rds-policy" {
+  name        = "pmm-demo-rds-policy"
+  path        = "/"
+  description = "Policy for rds database discovery"
+  policy = jsonencode({
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Sid" : "Stmt1508404837000",
+        "Effect" : "Allow",
+        "Action" : [
+          "rds:DescribeDBInstances",
+          "cloudwatch:GetMetricStatistics",
+          "cloudwatch:ListMetrics"
+        ],
+        "Resource" : ["*"]
+      },
+      {
+        "Sid" : "Stmt1508410723001",
+        "Effect" : "Allow",
+        "Action" : [
+          "logs:DescribeLogStreams",
+          "logs:GetLogEvents",
+          "logs:FilterLogEvents"
+        ],
+        "Resource" : ["arn:aws:logs:*:*:log-group:RDSOSMetrics:*"]
+      }
+  ] })
+}
+
+resource "aws_iam_role" "pmmdemo_dlm_lifecycle" {
+  name = "pmmdemo-dlm-lifecycle"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "dlm.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}

--- a/pmm/azure_resource_group.tf
+++ b/pmm/azure_resource_group.tf
@@ -1,0 +1,11 @@
+# Resource Group For Azure, Global resource
+
+resource "azurerm_resource_group" "pmmdemo" {
+  name     = "pmmdemov2"
+  provider = azurerm.demo
+  location = local.azure_region
+  tags = {
+    Terraform       = "Yes"
+    iit-billing-tag = "pmm-demo"
+  }
+}

--- a/pmmdemo/azure_mysql_80.tf
+++ b/pmmdemo/azure_mysql_80.tf
@@ -2,12 +2,20 @@ locals {
   azure_region = "East US"
 }
 
+# Import the resource group, as there can only be one and it should not
+# be recreated/destroyed each time someone wants to rebuild in Azure
+data "azurerm_resource_group" "pmmdemo" {
+  name = "pmmdemov2"
+  provider = azurerm.demo
+}
+
+# Create the Azure MySQL "RDS" server
 resource "azurerm_mysql_server" "pmmdemo" {
   name     = "pmmdemo-azure"
   provider = azurerm.demo
 
   location            = local.azure_region
-  resource_group_name = azurerm_resource_group.pmmdemo.name
+  resource_group_name = data.azurerm_resource_group.pmmdemo.name
 
   administrator_login          = "pmmdemo"
   administrator_login_password = random_password.azure_mysql.result
@@ -35,7 +43,7 @@ resource "azurerm_mysql_server" "pmmdemo" {
 resource "azurerm_mysql_database" "pmmdemo_sysbench" {
   name                = "sbtest"
   provider            = azurerm.demo
-  resource_group_name = azurerm_resource_group.pmmdemo.name
+  resource_group_name = data.azurerm_resource_group.pmmdemo.name
   server_name         = azurerm_mysql_server.pmmdemo.name
   charset             = "utf8"
   collation           = "utf8_unicode_ci"
@@ -46,20 +54,10 @@ resource "azurerm_mysql_database" "pmmdemo_sysbench" {
 resource "azurerm_mysql_firewall_rule" "allow_pmmdemo_server" {
   name                = "allow_pmmdemo_server"
   provider            = azurerm.demo
-  resource_group_name = azurerm_resource_group.pmmdemo.name
+  resource_group_name = data.azurerm_resource_group.pmmdemo.name
   server_name         = azurerm_mysql_server.pmmdemo.name
   start_ip_address    = aws_eip.external_ip.public_ip
   end_ip_address      = aws_eip.external_ip.public_ip
-}
-
-resource "azurerm_resource_group" "pmmdemo" {
-  name     = "pmmdemov2"
-  provider = azurerm.demo
-  location = local.azure_region
-  tags = {
-    Terraform       = "Yes"
-    iit-billing-tag = "pmm-demo"
-  }
 }
 
 resource "random_password" "azure_mysql" {

--- a/pmmdemo/provision_scripts/percona_server_80.yml
+++ b/pmmdemo/provision_scripts/percona_server_80.yml
@@ -80,6 +80,7 @@ write_files:
       #
       userstat=ON
       performance_schema=ON
+      innodb_monitor_enable=module_index
 
       # Async replication
       #

--- a/pmmdemo/provision_scripts/percona_xtradb_cluster_80.yml
+++ b/pmmdemo/provision_scripts/percona_xtradb_cluster_80.yml
@@ -78,6 +78,7 @@ write_files:
       #
       userstat=ON
       performance_schema=ON
+      innodb_monitor_enable=module_index
 
       # wsrep
       #


### PR DESCRIPTION
There are several resources that should be considered "global" and not subject to deletion/re-creation each time someone wants to deploy the TF plan inside the shared AWS account.
This PR moves the following:

- "aws_iam_policy" "pmmdemo-rds-policy"
- "aws_iam_role" "pmmdemo_dlm_lifecycle"
- "aws_iam_user" "rds_user"
- "azurerm_resource_group" "pmmdemo"

into /pmm/ for one-time creation on very first TF apply. After that, you shouldn't need to mess with them other than if they need modifications.