### PR TITLE
testing out raw timeout 60s

### DIFF
--- a/pmmdemo/provision_scripts/percona_server_80.yml
+++ b/pmmdemo/provision_scripts/percona_server_80.yml
@@ -28,6 +28,7 @@ runcmd:
   - bash /root/init-mysql.sh
   - timeout 120 bash -c 'until curl --request 'GET' --insecure https://${pmm_server_endpoint}/v1/readyz ; do sleep 3; done'
   - pmm-admin config --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
+  - timeout 60 bash -c 'until true ; do sleep 3; done'
   - pmm-admin add mysql --metrics-mode=push --username=pmm-admin --password='${mysql_root_password}' --cluster='ps-80-cluster' --replication-set='ps-80-cluster' --environment='prod' --query-source=perfschema --service-name=${name}
 
 write_files:


### PR DESCRIPTION
makes sure 
```
pmm-admin add mysql --service-name=percona-server-80-1-mysql
``` 
succeeds, as it needs to wait on the `CREATE USER pmm-admin@localhost` to replicate from `percona-server-80-0-mysql`  