### PR TITLE
remove uid and gid since docker, fix sorting

### DIFF
--- a/pmmdemo/provision_scripts/haproxy.yml
+++ b/pmmdemo/provision_scripts/haproxy.yml
@@ -22,38 +22,35 @@ write_files:
   - path: /etc/haproxy/haproxy.cfg
     content: |
       global
-              log 127.0.0.1   local0
-              log 127.0.0.1   local1 notice
-              maxconn 4096
-              user        haproxy
-              group       haproxy
-              daemon
-              stats socket /var/lib/haproxy/stats
+        daemon
+        log 127.0.0.1   local0
+        log 127.0.0.1   local1 notice
+        maxconn 4096
+        stats socket /var/lib/haproxy/stats
 
       defaults
-              log     global
-              mode    http
-              option  tcplog
-              option  dontlognull
-              retries 3
-              maxconn 2000
-              timeout connect      5000
-              timeout client      50000
-              timeout server     50000
+        log     global
+        maxconn 2000
+        mode    http
+        option  dontlognull
+        option  tcplog
+        retries 3
+        timeout client      50000
+        timeout connect      5000
+        timeout server      50000
 
       listen mysql-cluster
-          bind 0.0.0.0:3306
-          mode tcp
-          balance roundrobin
-          option mysql-check user haproxy_check
-
-          server db01 percona-xtradb-cluster-0:3306 rise 3 fall 3
-          server db02 percona-xtradb-cluster-1:3306 rise 3 fall 3
-          server db03 percona-xtradb-cluster-2:3306 rise 3 fall 3
+        balance roundrobin
+        bind 0.0.0.0:3306
+        mode tcp
+        option mysql-check user haproxy_check
+        server db01 percona-xtradb-cluster-0:3306 rise 3 fall 3
+        server db02 percona-xtradb-cluster-1:3306 rise 3 fall 3
+        server db03 percona-xtradb-cluster-2:3306 rise 3 fall 3
 
       frontend stats
-          bind *:8404
-          http-request use-service prometheus-exporter if { path /metrics }
-          stats enable
-          stats uri /stats
-          stats refresh 10s
+        bind *:8404
+        http-request use-service prometheus-exporter if { path /metrics }
+        stats enable
+        stats refresh 10s
+        stats uri /stats


### PR DESCRIPTION
with docker you don't need to drop privileges and this was throwing a warning in the logs. also cleaned up the sort order and spacing and indents.