### PR TITLE
Improve PS replica lag

### DIFF
--- a/pmmdemo/provision_scripts/percona_server_81.yml
+++ b/pmmdemo/provision_scripts/percona_server_81.yml
@@ -137,13 +137,13 @@ write_files:
   - path: /tmp/replica-config.cnf
     content: |
       [mysqld]
-      innodb_flush_log_at_trx_commit=1
+      innodb_flush_log_at_trx_commit=0
       innodb_flush_method=O_DIRECT
       innodb_flush_neighbors=0
       read_only=1
       replica_parallel_workers=2
       replica_preserve_commit_order=1
-      sync_binlog=1
+      sync_binlog=0
 
   - path: /root/init-mysql.sh
     permissions: "0555"

--- a/pmmdemo/provision_scripts/sysbench.yml
+++ b/pmmdemo/provision_scripts/sysbench.yml
@@ -84,7 +84,7 @@ write_files:
       OLTP_PATH='/usr/share/sysbench'
       for (( ; ; )); do
           RND_OLTP_BENCH="$${OLTP_AVAILABLE[RANDOM%$${#OLTP_AVAILABLE[@]}]}";
-          RND_NUM_THREADS="$(( $${RANDOM} % 10 + 6 ))";   # 8..16
+          RND_NUM_THREADS="$(( $${RANDOM} % 17 + 8 ))";   # 8..24
           RND_EXEC_TIME="$(( $${RANDOM} % 300 + 600 ))";    # 600..900
           echo -e "\nRunning: $${RND_OLTP_BENCH} - $(date "+%Y-%m-%d / %H:%M:%S")\n=======================";
           pmm-admin annotate "$${SYSBENCH_CFG} - $${RND_OLTP_BENCH}" --tags "$${SYSBENCH_CFG},$${RND_OLTP_BENCH}";
@@ -92,7 +92,6 @@ write_files:
           sysbench --config-file=/etc/sysbench/"$${SYSBENCH_CFG}" --threads="$${RND_NUM_THREADS}" --time="$${RND_EXEC_TIME}" "$${OLTP_PATH}/$${RND_OLTP_BENCH}" prepare;
           sysbench --config-file=/etc/sysbench/"$${SYSBENCH_CFG}" --threads="$${RND_NUM_THREADS}" --time="$${RND_EXEC_TIME}" "$${OLTP_PATH}/$${RND_OLTP_BENCH}" run;
           sysbench --config-file=/etc/sysbench/"$${SYSBENCH_CFG}" --threads="$${RND_NUM_THREADS}" --time="$${RND_EXEC_TIME}" "$${OLTP_PATH}/$${RND_OLTP_BENCH}" cleanup;
-          sleep 10
       done;
 
   - path: /etc/sysbench/ps80.cnf

--- a/pmmdemo/provision_scripts/sysbench.yml
+++ b/pmmdemo/provision_scripts/sysbench.yml
@@ -84,7 +84,7 @@ write_files:
       OLTP_PATH='/usr/share/sysbench'
       for (( ; ; )); do
           RND_OLTP_BENCH="$${OLTP_AVAILABLE[RANDOM%$${#OLTP_AVAILABLE[@]}]}";
-          RND_NUM_THREADS="$(( $${RANDOM} % 17 + 8 ))";   # 8..24
+          RND_NUM_THREADS="$(( $${RANDOM} % 10 + 6 ))";   # 8..16
           RND_EXEC_TIME="$(( $${RANDOM} % 300 + 600 ))";    # 600..900
           echo -e "\nRunning: $${RND_OLTP_BENCH} - $(date "+%Y-%m-%d / %H:%M:%S")\n=======================";
           pmm-admin annotate "$${SYSBENCH_CFG} - $${RND_OLTP_BENCH}" --tags "$${SYSBENCH_CFG},$${RND_OLTP_BENCH}";
@@ -92,6 +92,7 @@ write_files:
           sysbench --config-file=/etc/sysbench/"$${SYSBENCH_CFG}" --threads="$${RND_NUM_THREADS}" --time="$${RND_EXEC_TIME}" "$${OLTP_PATH}/$${RND_OLTP_BENCH}" prepare;
           sysbench --config-file=/etc/sysbench/"$${SYSBENCH_CFG}" --threads="$${RND_NUM_THREADS}" --time="$${RND_EXEC_TIME}" "$${OLTP_PATH}/$${RND_OLTP_BENCH}" run;
           sysbench --config-file=/etc/sysbench/"$${SYSBENCH_CFG}" --threads="$${RND_NUM_THREADS}" --time="$${RND_EXEC_TIME}" "$${OLTP_PATH}/$${RND_OLTP_BENCH}" cleanup;
+          sleep 10
       done;
 
   - path: /etc/sysbench/ps80.cnf


### PR DESCRIPTION
PS8.1 replica had filled up disks with relay logs. The 8.1 source was doing too many transactions for replica to handle. This PR reduces disk flushing on replica.