### PR TITLE
innodb improvements

### DIFF
--- a/pmmdemo/provision_scripts/percona_server_80.yml
+++ b/pmmdemo/provision_scripts/percona_server_80.yml
@@ -46,6 +46,7 @@ write_files:
       {
         "history.autoSave": "true"
       }
+
   - path: /etc/consul.d/consul.hcl
     permissions: "0644"
     content: |
@@ -71,12 +72,13 @@ write_files:
           "port": 3306,
           "checks": [
             {
-        "args": ["mysqladmin", "ping", "--host=127.0.0.1", "--port=3306", "--user=sysbench-proxysql-ps", "--password=${mysql_sysbench_password}"],
+              "args": ["mysqladmin", "ping", "--host=127.0.0.1", "--port=3306", "--user=sysbench-proxysql-ps", "--password=${mysql_sysbench_password}"],
               "interval": "10s"
             }
           ]
         }
       }
+
   - path: /root/.my.cnf
     content: |
       [client]
@@ -92,7 +94,6 @@ write_files:
       report_host = ${fqdn}
       report_port = 3306
       server_id   = 1${index}
-
 
       # Generic
       #
@@ -111,10 +112,11 @@ write_files:
       binlog_space_limit=10G
 
       # Configure slow logs
+      #
       slow_query_log=ON
       slow_query_log_always_write_time=1
       slow_query_log_use_global_control=all
-      log_slow_rate_limit=1
+      log_slow_rate_limit=2       # Log every other slow query
       log_slow_rate_type='query'
       log_slow_admin_statements=ON
       log_slow_replica_statements=ON
@@ -122,6 +124,12 @@ write_files:
       long_query_time=0
       #max_slowlog_size=3G
       #max_slowlog_files=3
+
+      # InnoDB
+      #
+      innodb_buffer_pool_size=1G
+      innodb_flush_method=O_DIRECT
+      innodb_adaptive_hash_index=OFF
 
       # Configure statistics
       #

--- a/pmmdemo/provision_scripts/percona_server_80.yml
+++ b/pmmdemo/provision_scripts/percona_server_80.yml
@@ -129,7 +129,6 @@ write_files:
       #
       innodb_buffer_pool_size=1G
       innodb_flush_method=O_DIRECT
-      innodb_adaptive_hash_index=OFF
 
       # Configure statistics
       #

--- a/pmmdemo/provision_scripts/percona_server_81.yml
+++ b/pmmdemo/provision_scripts/percona_server_81.yml
@@ -131,7 +131,6 @@ write_files:
       #
       innodb_buffer_pool_size=1G
       innodb_flush_method=O_DIRECT
-      innodb_adaptive_hash_index=OFF
 
       # Configure statistics
       #

--- a/pmmdemo/provision_scripts/percona_server_81.yml
+++ b/pmmdemo/provision_scripts/percona_server_81.yml
@@ -46,6 +46,7 @@ write_files:
       {
         "history.autoSave": "true"
       }
+
   - path: /etc/consul.d/consul.hcl
     permissions: "0644"
     content: |
@@ -59,6 +60,7 @@ write_files:
       ui_config{
         enabled = true
       }
+
   - path: /etc/consul.d/ps-service.json
     permissions: "0644"
     content: |
@@ -71,12 +73,13 @@ write_files:
           "port": 3306,
           "checks": [
             {
-        "args": ["mysqladmin", "ping", "--host=127.0.0.1", "--port=3306", "--user=sysbench-proxysql-ps81", "--password=${mysql_sysbench_password}"],
+              "args": ["mysqladmin", "ping", "--host=127.0.0.1", "--port=3306", "--user=sysbench-proxysql-ps81", "--password=${mysql_sysbench_password}"],
               "interval": "10s"
             }
           ]
         }
       }
+
   - path: /root/.my.cnf
     content: |
       [client]
@@ -111,6 +114,7 @@ write_files:
       binlog_space_limit=10G
 
       # Configure slow logs
+      #
       slow_query_log=ON
       slow_query_log_always_write_time=1
       slow_query_log_use_global_control=all
@@ -122,6 +126,12 @@ write_files:
       long_query_time=0
       #max_slowlog_size=3G
       #max_slowlog_files=3
+
+      # InnoDB
+      #
+      innodb_buffer_pool_size=1G
+      innodb_flush_method=O_DIRECT
+      innodb_adaptive_hash_index=OFF
 
       # Configure statistics
       #


### PR DESCRIPTION
I was investigating why percona-server-80-0 kept having high CPU alarms. Bufferpool was defaults. I also dialed back the slow query log to every-other because PMM showed in P_S graphs that slow log was the highest wait.

Do we want to show tuned MySQL's? Or do we want to show misconfigured MySQL and their effects?