### PR TITLE
always adhere to validate-password-policy MEDIUM

### DIFF
--- a/pmmdemo/percona_server_80.tf
+++ b/pmmdemo/percona_server_80.tf
@@ -22,10 +22,7 @@ module "percona_server_80" {
 }
 
 resource "random_password" "mysql80_root_password" {
-  length      = 30
-  special     = false
-  upper       = true
-  numeric     = true
+  length      = 8
   min_lower   = 1
   min_numeric = 1
   min_special = 1
@@ -33,10 +30,7 @@ resource "random_password" "mysql80_root_password" {
 }
 
 resource "random_password" "mysql80_replica_password" {
-  length      = 30
-  special     = false
-  upper       = true
-  numeric     = true
+  length      = 8
   min_lower   = 1
   min_numeric = 1
   min_special = 1
@@ -44,12 +38,10 @@ resource "random_password" "mysql80_replica_password" {
 }
 
 resource "random_password" "mysql80_sysbench_password" {
-  length      = 30
-  special     = false
-  upper       = true
-  numeric     = true
+  length      = 8
   min_lower   = 1
   min_numeric = 1
+  min_special = 1
   min_upper   = 1
 }
 

--- a/pmmdemo/percona_server_81.tf
+++ b/pmmdemo/percona_server_81.tf
@@ -23,9 +23,6 @@ module "percona_server_81" {
 
 resource "random_password" "mysql81_root_password" {
   length      = 8
-  special     = false
-  upper       = true
-  numeric     = true
   min_lower   = 1
   min_numeric = 1
   min_special = 1
@@ -34,9 +31,6 @@ resource "random_password" "mysql81_root_password" {
 
 resource "random_password" "mysql81_replica_password" {
   length      = 8
-  special     = false
-  upper       = true
-  numeric     = true
   min_lower   = 1
   min_numeric = 1
   min_special = 1
@@ -45,12 +39,10 @@ resource "random_password" "mysql81_replica_password" {
 
 resource "random_password" "mysql81_sysbench_password" {
   length      = 8
-  special     = false
-  upper       = true
-  numeric     = true
   min_lower   = 1
   min_numeric = 1
   min_upper   = 1
+  min_special = 1
 }
 
 data "template_file" "percona_server_81_user_data" {

--- a/pmmdemo/percona_xtradb_cluster_80.tf
+++ b/pmmdemo/percona_xtradb_cluster_80.tf
@@ -19,17 +19,19 @@ module "percona_xtradb_cluster_80" {
 }
 
 resource "random_password" "percona_xtradb_cluster_80_root_password" {
-  length  = 30
-  special = false
-  upper   = true
-  numeric = true
+  length      = 8
+  min_lower   = 1
+  min_numeric = 1
+  min_special = 1
+  min_upper   = 1
 }
 
 resource "random_password" "percona_xtradb_cluster_80_sysbench_password" {
-  length  = 30
-  special = false
-  upper   = true
-  numeric = true
+  length      = 8
+  min_lower   = 1
+  min_numeric = 1
+  min_special = 1
+  min_upper   = 1
 }
 
 data "template_file" "percona_xtradb_cluster_80_user_data" {

--- a/pmmdemo/pmm_server.tf
+++ b/pmmdemo/pmm_server.tf
@@ -40,8 +40,10 @@ module "pmm_server_disk" {
 }
 
 resource "random_password" "pmm_admin_pass" {
-  length  = 20
+  length  = 8
   special = false
+  lower   = false
+  numeric = false
 }
 
 data "aws_iam_user" "rds_user" {

--- a/pmmdemo/proxysql_20.tf
+++ b/pmmdemo/proxysql_20.tf
@@ -12,35 +12,38 @@ module "proxysql" {
     aws_security_group.default_access.id,
   ]
   user_data = templatefile("provision_scripts/proxysql_20.yml", {
-    name                               = local.proxysql_name
-    domain                             = var.pmm_domain
-    pmm_admin_password                 = random_password.pmm_admin_pass.result
-    pmm_server_endpoint                = local.pmm_server_endpoint
-    fqdn                               = "${local.proxysql_name}.${aws_route53_zone.demo_local.name}"
-    proxysql_monitor_password          = random_password.proxysql_monitor.result
-    proxysql_admin_password            = random_password.proxysql_admin.result
-    percona_server_80_password         = random_password.mysql80_sysbench_password.result
-    percona_server_81_password         = random_password.mysql81_sysbench_password.result
-    percona_xtradb_cluster_80_password = random_password.percona_xtradb_cluster_80_sysbench_password.result
+    name                                  = local.proxysql_name
+    domain                                = var.pmm_domain
+    pmm_admin_password                    = random_password.pmm_admin_pass.result
+    pmm_server_endpoint                   = local.pmm_server_endpoint
+    fqdn                                  = "${local.proxysql_name}.${aws_route53_zone.demo_local.name}"
+    proxysql_monitor_password             = random_password.proxysql_monitor.result
+    proxysql_admin_password               = random_password.proxysql_admin.result
+    percona_server_80_password            = random_password.mysql80_sysbench_password.result
+    percona_server_81_password            = random_password.mysql81_sysbench_password.result
+    percona_xtradb_cluster_80_password    = random_password.percona_xtradb_cluster_80_sysbench_password.result
   })
 
   depends_on = [
     module.pmm_server,
     module.percona_server_80,
-    module.percona_xtradb_cluster_80
+    module.percona_server_81,
+    module.percona_xtradb_cluster_80,
   ]
 }
 
 resource "random_password" "proxysql_monitor" {
-  length  = 30
-  special = false
-  upper   = true
-  numeric = true
+  length      = 8
+  min_lower   = 1
+  min_numeric = 1
+  min_special = 1
+  min_upper   = 1
 }
 
 resource "random_password" "proxysql_admin" {
-  length  = 30
-  special = false
-  upper   = true
-  numeric = true
+  length      = 8
+  min_lower   = 1
+  min_numeric = 1
+  min_special = 1
+  min_upper   = 1
 }


### PR DESCRIPTION
sometimes random_password would generate a password that doesn't meet the complexity expected by MySQL's validate password plugin, and then some deployments would fail in super crappy authentication ways.  So this makes sure we always deploy 8 characters with sufficient complexity to comply with MySQL defaults. 