### PR TITLE
helpful if you repeatedly blow away bastion

### DIFF
--- a/pmmdemo/provision_scripts/bastion.yml
+++ b/pmmdemo/provision_scripts/bastion.yml
@@ -28,7 +28,7 @@ runcmd:
   - until nc -z localhost 80; do sleep 1; done
   - docker exec nginx apt update
   - docker exec nginx apt install -y certbot python3-certbot-nginx
-  - docker exec nginx certbot --nginx --non-interactive --agree-tos -m ${email} -d ${domain}
+  - docker exec nginx certbot --nginx --non-interactive --agree-tos --test-cert -m ${email} -d ${domain}
   - echo "${pmm_admin_pass}" > /root/pmm-admin_password
   - chmod 400 /root/pmm-admin_password
 


### PR DESCRIPTION
you get more API hits this way,  if you are frequently running -destroy against bastion.
For Production deployment we ought to remove it.