### PR TITLE
Set cpu_credits to standard

### DIFF
--- a/pmmdemo/modules/ec2/ec2.tf
+++ b/pmmdemo/modules/ec2/ec2.tf
@@ -5,6 +5,7 @@ resource "aws_instance" "ec2" {
   subnet_id                   = var.subnet_id
   vpc_security_group_ids      = var.security_groups
   user_data                   = var.user_data
+  cpu_credits                 = var.cpu_credits_mode
 
   key_name = data.aws_key_pair.pmm-demo.key_name
 

--- a/pmmdemo/modules/ec2/vars.tf
+++ b/pmmdemo/modules/ec2/vars.tf
@@ -49,3 +49,9 @@ variable "user_data" {
   default     = ""
   description = "User data to provide when launching the instance"
 }
+
+variable "cpu_credits_mode" {
+  type        = bool
+  default     = "standard"
+  description = "EC2 burstable credits - standard or unlimited"
+}


### PR DESCRIPTION
We were spending an extra $400/month for burstable credits when we don't need the instances to  crank out more work.  Setting to standard keeps instances accruing credits and  spending them but will not incur unplanned expenses.