### PR TITLE
support opentofu and make gr bootable

### DIFF
--- a/pmmdemo/provider.tf
+++ b/pmmdemo/provider.tf
@@ -13,7 +13,6 @@ terraform {
       version = "3.0.2"
     }
   }
-  required_version = "~> 1.3.4"
 
   backend "s3" {
     bucket = "percona-terraform"

--- a/pmmdemo/provision_scripts/percona_group_replication_81.yml
+++ b/pmmdemo/provision_scripts/percona_group_replication_81.yml
@@ -22,8 +22,6 @@ runcmd:
   - systemctl enable consul
   - systemctl start consul
   - yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm
-  - percona-release enable mysql-shell
-  - yum -y install percona-mysql-shell
   - percona-release enable tools release
   - yum install -y pmm2-client
   - bash /usr/local/bin/waiter.sh readyz


### PR DESCRIPTION
gr config is hitting the max cloud-config 16K size. probably if we use "encoding=gzip" for our write_files we would be able to support more code in cloud-config and stave off Puppet