### PR TITLE
Reduce size of provision scripts yaml files

### DIFF
--- a/pmmdemo/provision_scripts/bastion.yml
+++ b/pmmdemo/provision_scripts/bastion.yml
@@ -43,6 +43,8 @@ runcmd:
   - dnf install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm
   - percona-release setup -y pmm3-client
   - dnf install -y pmm-client
+  - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
+  - chmod 0755 /usr/local/bin/waiter.sh
   - bash /usr/local/bin/waiter.sh readyz
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_admin_pass}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
@@ -134,61 +136,7 @@ write_files:
     content: |
       #!/bin/bash
       # Script to do all the waiting
-      service="$1"
-      if [[ $service == "process-exporter" ]]; then
-        # process-exporter
-        while true; do
-          # Get the status of the process-exporter_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.process-exporter.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.process-exporter.service.consul." ]]; then
-            echo "process-exporter check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "process-exporter check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "proxysql" ]]; then
-        # proxysql
-        while true; do
-          # Get the status of the Proxysql check
-          status=$(dig @127.0.0.1 -p 8600 proxysql.service.consul SRV | awk '/SRV.*proxysql.${environment_name}.$/ {print $1}')
-
-          if [[ $status == "proxysql.service.consul." ]]; then
-            echo "ProxySQL check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "ProxySQL check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "readyz" ]] ; then
-        # PMM readyz
-        while true; do
-          # Check for DNS :facepalm:
-          dnsstatus=$(dig pmm-server.${environment_name}.local A | awk '/A.*10.*$/ {print $1}')
-
-          if [[ $dnsstatus == "pmm-server.${environment_name}.local." ]]; then
-            echo "PMMreadyz_check_http DNS check is passing."
-
-            # Get the status of the PMMreadyz_check_http check
-            status=$(dig @127.0.0.1 -p 8600 pmmreadyz.service.consul SRV | awk '/SRV.*bastion.${environment_name}.local.$/ {print $1}')
-
-            if [[ $status == "pmmreadyz.service.consul." ]]; then
-              echo "PMMreadyz_check_http check is passing."
-              exit 0  
-            fi
-          else
-            echo "PMMreadyz_check_http DNS check is not passing."
-          fi
-          # If the check is not passing, wait for a short interval and try again
-          echo "PMMreadyz_check_http check is not passing. Will retry in 1 second..."
-          sleep 1
-        done
-      fi
+      # File contents will be downloaded from githubcontent.com
   - path: /root/.ssh/config
     content: |
       Host *

--- a/pmmdemo/provision_scripts/bastion.yml
+++ b/pmmdemo/provision_scripts/bastion.yml
@@ -45,10 +45,10 @@ runcmd:
   - dnf install -y pmm-client
   - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
   - chmod 0755 /usr/local/bin/waiter.sh
-  - bash /usr/local/bin/waiter.sh readyz
+  - bash /usr/local/bin/waiter.sh readyz  ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_admin_pass}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
-  - bash /usr/local/bin/waiter.sh process-exporter
+  - bash /usr/local/bin/waiter.sh process-exporter ${name} ${fqdn} ${environment_name}
   - pmm-admin add external --group=processes --listen-port=9256 --environment="prod" --service-name="${name}-processes" --cluster="processes-cluster"
 
 write_files:

--- a/pmmdemo/provision_scripts/haproxy.yml
+++ b/pmmdemo/provision_scripts/haproxy.yml
@@ -24,12 +24,12 @@ runcmd:
   - dnf -y install pmm-client
   - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
   - chmod 0755 /usr/local/bin/waiter.sh
-  - bash /usr/local/bin/waiter.sh readyz
+  - bash /usr/local/bin/waiter.sh readyz ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_admin_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
-  - bash /usr/local/bin/waiter.sh haproxy-exporter
+  - bash /usr/local/bin/waiter.sh haproxy-exporter ${name} ${fqdn} ${environment_name
   - pmm-admin add haproxy --listen-port=8404 --metrics-path=/metrics --environment="prod" --cluster="haproxy" --replication-set="haproxy"
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
-  - bash /usr/local/bin/waiter.sh process-exporter
+  - bash /usr/local/bin/waiter.sh process-exporter ${name} ${fqdn} ${environment_name}
   - pmm-admin add external --group=processes --listen-port=9256 --environment="prod" --service-name="${name}-processes" --cluster="processes-cluster"
 
 write_files:

--- a/pmmdemo/provision_scripts/haproxy.yml
+++ b/pmmdemo/provision_scripts/haproxy.yml
@@ -22,6 +22,8 @@ runcmd:
   - dnf -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm
   - percona-release setup -y pmm3-client
   - dnf -y install pmm-client
+  - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
+  - chmod 0755 /usr/local/bin/waiter.sh
   - bash /usr/local/bin/waiter.sh readyz
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_admin_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - bash /usr/local/bin/waiter.sh haproxy-exporter
@@ -112,61 +114,7 @@ write_files:
     content: |
       #!/bin/bash
       # Script to do all the waiting
-      service="$1"
-      if [[ $service == "process-exporter" ]]; then
-        # process-exporter
-        while true; do
-          # Get the status of the process-exporter_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.process-exporter.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.process-exporter.service.consul." ]]; then
-            echo "process-exporter check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "process-exporter check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "readyz" ]] ; then
-        # PMM readyz
-        while true; do
-          # Check for DNS :facepalm:
-          dnsstatus=$(dig pmm-server.${environment_name}.local A | awk '/A.*10.*$/ {print $1}')
-
-          if [[ $dnsstatus == "pmm-server.${environment_name}.local." ]]; then
-            echo "PMMreadyz_check_http DNS check is passing."
-
-            # Get the status of the PMMreadyz_check_http check
-            status=$(dig @127.0.0.1 -p 8600 pmmreadyz.service.consul SRV | awk '/SRV.*bastion.${environment_name}.local.$/ {print $1}')
-        
-            if [[ $status == "pmmreadyz.service.consul." ]]; then
-              echo "PMMreadyz_check_http check is passing."
-              exit 0  
-            fi
-          else
-            echo "PMMreadyz_check_http DNS check is not passing."
-          fi
-          # If the check is not passing, wait for a short interval and try again
-          echo "PMMreadyz_check_http check is not passing. Will retry in 1 second..."
-          sleep 1
-        done
-      elif [[ $service == "haproxy-exporter" ]]; then
-        # haproxy-exporter
-        while true; do
-          # Get the status of the haproxy-exporter_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.haproxy-exporter.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.haproxy-exporter.service.consul." ]]; then
-            echo "haproxy-exporter check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "haproxy-exporter check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      fi
+      # File contents will be downloaded from githubcontent.com
   - path: /etc/haproxy/haproxy.cfg
     content: |
       global

--- a/pmmdemo/provision_scripts/mongo_60/cfg.yml
+++ b/pmmdemo/provision_scripts/mongo_60/cfg.yml
@@ -27,10 +27,10 @@ runcmd:
   - dnf -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm
   - percona-release setup -y pmm3-client
   - dnf -y install pmm-client
-  - bash /usr/local/bin/waiter.sh readyz
+  - bash /usr/local/bin/waiter.sh readyz ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
-  - bash /usr/local/bin/waiter.sh process-exporter
+  - bash /usr/local/bin/waiter.sh process-exporter ${name} ${fqdn} ${environment_name}
   - pmm-admin add external --group=processes --listen-port=9256 --environment="prod" --service-name="${name}-processes" --cluster="processes-cluster"
   - percona-release setup -y psmdb-60
   - dnf -y install percona-server-mongodb

--- a/pmmdemo/provision_scripts/mongo_60/cfg.yml
+++ b/pmmdemo/provision_scripts/mongo_60/cfg.yml
@@ -27,6 +27,8 @@ runcmd:
   - dnf -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm
   - percona-release setup -y pmm3-client
   - dnf -y install pmm-client
+  - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
+  - chmod 0755 /usr/local/bin/waiter.sh
   - bash /usr/local/bin/waiter.sh readyz ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
@@ -49,59 +51,7 @@ write_files:
     content: |
       #!/bin/bash
       # Script to do all the waiting
-      service="$1"
-      if [[ $service == "process-exporter" ]]; then
-        # process-exporter
-        while true; do
-          # Get the status of the process-exporter_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.process-exporter.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.process-exporter.service.consul." ]]; then
-            echo "process-exporter check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "process-exporter check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "mongodb" ]]; then
-        # mongodb
-        while true; do
-          # Get the status of the mongodb check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.mongo-60-${replica_set_name}.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-          if [[ $status == "${name}.mongo-60-${replica_set_name}.service.consul." ]]; then
-            echo "mongodb check is passing."
-            exit 0
-          fi
-          # If the check is not passing, wait for a short interval and try again
-          echo "mongodb check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "readyz" ]] ; then
-        # PMM readyz
-        while true; do
-          # Check for DNS :facepalm:
-          dnsstatus=$(dig pmm-server.${environment_name}.local A | awk '/A.*10.*$/ {print $1}')
-
-          if [[ $dnsstatus == "pmm-server.${environment_name}.local." ]]; then
-            echo "PMMreadyz_check_http DNS check is passing."
-
-            # Get the status of the PMMreadyz_check_http check
-            status=$(dig @127.0.0.1 -p 8600 pmmreadyz.service.consul SRV | awk '/SRV.*bastion.${environment_name}.local.$/ {print $1}')
-        
-            if [[ $status == "pmmreadyz.service.consul." ]]; then
-              echo "PMMreadyz_check_http check is passing."
-              exit 0  
-            fi
-          else
-            echo "PMMreadyz_check_http DNS check is not passing."
-          fi
-          # If the check is not passing, wait for a short interval and try again
-          echo "PMMreadyz_check_http check is not passing. Will retry in 1 second..."
-          sleep 1
-        done
-      fi
+      # File contents will be downloaded from githubcontent.com
   - path: /etc/consul.d/consul.hcl
     permissions: "0644"
     content: |

--- a/pmmdemo/provision_scripts/mongo_60/mongos.yml
+++ b/pmmdemo/provision_scripts/mongo_60/mongos.yml
@@ -19,10 +19,10 @@ runcmd:
   - dnf -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm
   - percona-release setup -y pmm3-client
   - dnf -y install pmm-client
-  - bash /usr/local/bin/waiter.sh readyz
+  - bash /usr/local/bin/waiter.sh readyz ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
-  - bash /usr/local/bin/waiter.sh process-exporter
+  - bash /usr/local/bin/waiter.sh process-exporter ${name} ${fqdn} ${environment_name}
   - pmm-admin add external --group=processes --listen-port=9256 --environment="prod" --service-name="${name}-processes" --cluster="processes-cluster"
   - percona-release setup -y psmdb-60
   - dnf -y install percona-server-mongodb

--- a/pmmdemo/provision_scripts/mongo_60/mongos.yml
+++ b/pmmdemo/provision_scripts/mongo_60/mongos.yml
@@ -19,6 +19,8 @@ runcmd:
   - dnf -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm
   - percona-release setup -y pmm3-client
   - dnf -y install pmm-client
+  - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
+  - chmod 0755 /usr/local/bin/waiter.sh
   - bash /usr/local/bin/waiter.sh readyz ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
@@ -44,59 +46,7 @@ write_files:
     content: |
       #!/bin/bash
       # Script to do all the waiting
-      service="$1"
-      if [[ $service == "process-exporter" ]]; then
-        # process-exporter
-        while true; do
-          # Get the status of the process-exporter_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.process-exporter.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.process-exporter.service.consul." ]]; then
-            echo "process-exporter check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "process-exporter check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "mongodb" ]]; then
-        # mongodb
-        while true; do
-          # Get the status of the mongodb check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.mongos.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-          if [[ $status == "${name}.mongos.service.consul." ]]; then
-            echo "mongodb check is passing."
-            exit 0
-          fi
-          # If the check is not passing, wait for a short interval and try again
-          echo "mongodb check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "readyz" ]] ; then
-        # PMM readyz
-        while true; do
-          # Check for DNS :facepalm:
-          dnsstatus=$(dig pmm-server.${environment_name}.local A | awk '/A.*10.*$/ {print $1}')
-
-          if [[ $dnsstatus == "pmm-server.${environment_name}.local." ]]; then
-            echo "PMMreadyz_check_http DNS check is passing."
-
-            # Get the status of the PMMreadyz_check_http check
-            status=$(dig @127.0.0.1 -p 8600 pmmreadyz.service.consul SRV | awk '/SRV.*bastion.${environment_name}.local.$/ {print $1}')
-        
-            if [[ $status == "pmmreadyz.service.consul." ]]; then
-              echo "PMMreadyz_check_http check is passing."
-              exit 0  
-            fi
-          else
-            echo "PMMreadyz_check_http DNS check is not passing."
-          fi
-          # If the check is not passing, wait for a short interval and try again
-          echo "PMMreadyz_check_http check is not passing. Will retry in 1 second..."
-          sleep 1
-        done
-      fi
+      # File contents will be downloaded from githubcontent.com
   - path: /etc/consul.d/consul.hcl
     permissions: "0644"
     content: |

--- a/pmmdemo/provision_scripts/mongo_60/shard.yml
+++ b/pmmdemo/provision_scripts/mongo_60/shard.yml
@@ -27,6 +27,8 @@ runcmd:
   - dnf -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm
   - percona-release setup -y pmm3-client
   - dnf -y install pmm-client
+  - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
+  - chmod 0755 /usr/local/bin/waiter.sh
   - bash /usr/local/bin/waiter.sh readyz ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
@@ -49,59 +51,7 @@ write_files:
     content: |
       #!/bin/bash
       # Script to do all the waiting
-      service="$1"
-      if [[ $service == "process-exporter" ]]; then
-        # process-exporter
-        while true; do
-          # Get the status of the process-exporter_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.process-exporter.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.process-exporter.service.consul." ]]; then
-            echo "process-exporter check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "process-exporter check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "mongodb" ]]; then
-        # mongodb
-        while true; do
-          # Get the status of the mongodb check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.mongo-60-rs-${shard_number}.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-          if [[ $status == "${name}.mongo-60-rs-${shard_number}.service.consul." ]]; then
-            echo "mongodb check is passing."
-            exit 0
-          fi
-          # If the check is not passing, wait for a short interval and try again
-          echo "mongodb check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "readyz" ]] ; then
-        # PMM readyz
-        while true; do
-          # Check for DNS :facepalm:
-          dnsstatus=$(dig pmm-server.${environment_name}.local A | awk '/A.*10.*$/ {print $1}')
-
-          if [[ $dnsstatus == "pmm-server.${environment_name}.local." ]]; then
-            echo "PMMreadyz_check_http DNS check is passing."
-
-            # Get the status of the PMMreadyz_check_http check
-            status=$(dig @127.0.0.1 -p 8600 pmmreadyz.service.consul SRV | awk '/SRV.*bastion.${environment_name}.local.$/ {print $1}')
-        
-            if [[ $status == "pmmreadyz.service.consul." ]]; then
-              echo "PMMreadyz_check_http check is passing."
-              exit 0  
-            fi
-          else
-            echo "PMMreadyz_check_http DNS check is not passing."
-          fi
-          # If the check is not passing, wait for a short interval and try again
-          echo "PMMreadyz_check_http check is not passing. Will retry in 1 second..."
-          sleep 1
-        done
-      fi
+      # File contents will be downloaded from githubcontent.com
   - path: /etc/consul.d/consul.hcl
     permissions: "0644"
     content: |

--- a/pmmdemo/provision_scripts/mongo_60/shard.yml
+++ b/pmmdemo/provision_scripts/mongo_60/shard.yml
@@ -27,10 +27,10 @@ runcmd:
   - dnf -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm
   - percona-release setup -y pmm3-client
   - dnf -y install pmm-client
-  - bash /usr/local/bin/waiter.sh readyz
+  - bash /usr/local/bin/waiter.sh readyz ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
-  - bash /usr/local/bin/waiter.sh process-exporter
+  - bash /usr/local/bin/waiter.sh process-exporter ${name} ${fqdn} ${environment_name}
   - pmm-admin add external --group=processes --listen-port=9256 --environment="prod" --service-name="${name}-processes" --cluster="processes-cluster"
   - percona-release setup -y psmdb-60
   - dnf -y install percona-server-mongodb

--- a/pmmdemo/provision_scripts/percona_server_80.yml
+++ b/pmmdemo/provision_scripts/percona_server_80.yml
@@ -35,6 +35,8 @@ runcmd:
   - systemctl start mysqld.service
   - systemctl status mysqld.service
   - bash /root/init-mysql.sh
+  - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
+  - chmod 0755 /usr/local/bin/waiter.sh
   - bash /usr/local/bin/waiter.sh readyz
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - bash /usr/local/bin/waiter.sh mysql
@@ -139,61 +141,7 @@ write_files:
     content: |
       #!/bin/bash
       # Script to do all the waiting
-      service="$1"
-      if [[ $service == "process-exporter" ]]; then
-        # process-exporter
-        while true; do
-          # Get the status of the process-exporter_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.process-exporter.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.process-exporter.service.consul." ]]; then
-            echo "process-exporter check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "process-exporter check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "mysql" ]]; then
-        # mysql
-        while true; do
-          # Get the status of the mysql_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.percona-server-80.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.percona-server-80.service.consul." ]]; then
-            echo "mysql check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "mysql check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "readyz" ]] ; then
-        # PMM readyz
-        while true; do
-          # Check for DNS :facepalm:
-          dnsstatus=$(dig pmm-server.${environment_name}.local A | awk '/A.*10.*$/ {print $1}')
-
-          if [[ $dnsstatus == "pmm-server.${environment_name}.local." ]]; then
-            echo "PMMreadyz_check_http DNS check is passing."
-
-            # Get the status of the PMMreadyz_check_http check
-            status=$(dig @127.0.0.1 -p 8600 pmmreadyz.service.consul SRV | awk '/SRV.*bastion.${environment_name}.local.$/ {print $1}')
-        
-            if [[ $status == "pmmreadyz.service.consul." ]]; then
-              echo "PMMreadyz_check_http check is passing."
-              exit 0  
-            fi
-          else
-            echo "PMMreadyz_check_http DNS check is not passing."
-          fi
-          # If the check is not passing, wait for a short interval and try again
-          echo "PMMreadyz_check_http check is not passing. Will retry in 1 second..."
-          sleep 1
-        done
-      fi
+      # File contents will be downloaded from githubcontent.com
   - path: /root/.my.cnf
     content: |
       [client]

--- a/pmmdemo/provision_scripts/percona_server_80.yml
+++ b/pmmdemo/provision_scripts/percona_server_80.yml
@@ -37,12 +37,12 @@ runcmd:
   - bash /root/init-mysql.sh
   - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
   - chmod 0755 /usr/local/bin/waiter.sh
-  - bash /usr/local/bin/waiter.sh readyz
+  - bash /usr/local/bin/waiter.sh readyz ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - bash /usr/local/bin/waiter.sh mysql
   - pmm-admin add mysql --metrics-mode=push --username=pmm-admin --password='${mysql_root_password}' --cluster='ps-80-cluster' --replication-set='ps-80-cluster' --environment='prod' --query-source=slowlog --service-name="${name}-mysql"
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
-  - bash /usr/local/bin/waiter.sh process-exporter
+  - bash /usr/local/bin/waiter.sh process-exporter ${name} ${fqdn} ${environment_name}
   - pmm-admin add external --group=processes --listen-port=9256 --environment="prod" --service-name="${name}-processes" --cluster="processes-cluster"
 
 write_files:

--- a/pmmdemo/provision_scripts/percona_server_84.yml
+++ b/pmmdemo/provision_scripts/percona_server_84.yml
@@ -37,12 +37,12 @@ runcmd:
   - bash /root/init-mysql.sh
   - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
   - chmod 0755 /usr/local/bin/waiter.sh
-  - bash /usr/local/bin/waiter.sh readyz
+  - bash /usr/local/bin/waiter.sh readyz ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - bash /usr/local/bin/waiter.sh mysql
   - pmm-admin add mysql --metrics-mode=push --username=pmm-admin --password='${mysql_root_password}' --cluster='ps-84-cluster' --replication-set='ps-84-cluster' --environment='prod' --query-source=slowlog --service-name="${name}-mysql"
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
-  - bash /usr/local/bin/waiter.sh process-exporter
+  - bash /usr/local/bin/waiter.sh process-exporter ${name} ${fqdn} ${environment_name}
   - pmm-admin add external --group=processes --listen-port=9256 --environment="prod" --service-name="${name}-processes" --cluster="processes-cluster"
 
 write_files:

--- a/pmmdemo/provision_scripts/percona_server_84.yml
+++ b/pmmdemo/provision_scripts/percona_server_84.yml
@@ -35,6 +35,8 @@ runcmd:
   - systemctl start mysqld.service
   - systemctl status mysqld.service
   - bash /root/init-mysql.sh
+  - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
+  - chmod 0755 /usr/local/bin/waiter.sh
   - bash /usr/local/bin/waiter.sh readyz
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - bash /usr/local/bin/waiter.sh mysql
@@ -139,61 +141,7 @@ write_files:
     content: |
       #!/bin/bash
       # Script to do all the waiting
-      service="$1"
-      if [[ $service == "process-exporter" ]]; then
-        # process-exporter
-        while true; do
-          # Get the status of the process-exporter_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.process-exporter.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.process-exporter.service.consul." ]]; then
-            echo "process-exporter check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "process-exporter check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "mysql" ]]; then
-        # mysql
-        while true; do
-          # Get the status of the mysql_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.percona-server-84.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.percona-server-84.service.consul." ]]; then
-            echo "mysql check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "mysql check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "readyz" ]] ; then
-        # PMM readyz
-        while true; do
-          # Check for DNS :facepalm:
-          dnsstatus=$(dig pmm-server.${environment_name}.local A | awk '/A.*10.*$/ {print $1}')
-
-          if [[ $dnsstatus == "pmm-server.${environment_name}.local." ]]; then
-            echo "PMMreadyz_check_http DNS check is passing."
-
-            # Get the status of the PMMreadyz_check_http check
-            status=$(dig @127.0.0.1 -p 8600 pmmreadyz.service.consul SRV | awk '/SRV.*bastion.${environment_name}.local.$/ {print $1}')
-        
-            if [[ $status == "pmmreadyz.service.consul." ]]; then
-              echo "PMMreadyz_check_http check is passing."
-              exit 0  
-            fi
-          else
-            echo "PMMreadyz_check_http DNS check is not passing."
-          fi
-          # If the check is not passing, wait for a short interval and try again
-          echo "PMMreadyz_check_http check is not passing. Will retry in 1 second..."
-          sleep 1
-        done
-      fi
+      # File contents will be downloaded from githubcontent.com
   - path: /root/.my.cnf
     content: |
       [client]

--- a/pmmdemo/provision_scripts/percona_server_84_group_replication.yml
+++ b/pmmdemo/provision_scripts/percona_server_84_group_replication.yml
@@ -37,12 +37,12 @@ runcmd:
   - bash /root/init-mysql.sh
   - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
   - chmod 0755 /usr/local/bin/waiter.sh
-  - bash /usr/local/bin/waiter.sh readyz
+  - bash /usr/local/bin/waiter.sh readyz ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - bash /usr/local/bin/waiter.sh mysql
   - pmm-admin add mysql --metrics-mode=push --username=pmm-admin --password='${mysql_root_password}' --cluster='percona-server-84-group-replication-cluster' --replication-set='percona-server-84-group-replication-cluster' --environment='prod' --query-source=slowlog --service-name="${name}-mysql"
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
-  - bash /usr/local/bin/waiter.sh process-exporter
+  - bash /usr/local/bin/waiter.sh process-exporter ${name} ${fqdn} ${environment_name}
   - pmm-admin add external --group=processes --listen-port=9256 --environment="prod" --service-name="${name}-processes" --cluster="processes-cluster"
 
 write_files:

--- a/pmmdemo/provision_scripts/percona_server_84_group_replication.yml
+++ b/pmmdemo/provision_scripts/percona_server_84_group_replication.yml
@@ -35,6 +35,8 @@ runcmd:
   - systemctl start mysqld.service
   - systemctl status mysqld.service
   - bash /root/init-mysql.sh
+  - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
+  - chmod 0755 /usr/local/bin/waiter.sh
   - bash /usr/local/bin/waiter.sh readyz
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - bash /usr/local/bin/waiter.sh mysql
@@ -139,61 +141,7 @@ write_files:
     content: |
       #!/bin/bash
       # Script to do all the waiting
-      service="$1"
-      if [[ $service == "process-exporter" ]]; then
-        # process-exporter
-        while true; do
-          # Get the status of the process-exporter_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.process-exporter.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.process-exporter.service.consul." ]]; then
-            echo "process-exporter check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "process-exporter check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "mysql" ]]; then
-        # mysql
-        while true; do
-          # Get the status of the mysql_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.percona-server-84-group-replication.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.percona-server-84-group-replication.service.consul." ]]; then
-            echo "mysql check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "mysql check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "readyz" ]] ; then
-        # PMM readyz
-        while true; do
-          # Check for DNS :facepalm:
-          dnsstatus=$(dig pmm-server.${environment_name}.local A | awk '/A.*10.*$/ {print $1}')
-
-          if [[ $dnsstatus == "pmm-server.${environment_name}.local." ]]; then
-            echo "PMMreadyz_check_http DNS check is passing."
-
-            # Get the status of the PMMreadyz_check_http check
-            status=$(dig @127.0.0.1 -p 8600 pmmreadyz.service.consul SRV | awk '/SRV.*bastion.${environment_name}.local.$/ {print $1}')
-        
-            if [[ $status == "pmmreadyz.service.consul." ]]; then
-              echo "PMMreadyz_check_http check is passing."
-              exit 0  
-            fi
-          else
-            echo "PMMreadyz_check_http DNS check is not passing."
-          fi
-          # If the check is not passing, wait for a short interval and try again
-          echo "PMMreadyz_check_http check is not passing. Will retry in 1 second..."
-          sleep 1
-        done
-      fi
+      # File contents will be downloaded from githubcontent.com
   - path: /root/.my.cnf
     content: |
       [client]

--- a/pmmdemo/provision_scripts/percona_xtradb_cluster_80.yml
+++ b/pmmdemo/provision_scripts/percona_xtradb_cluster_80.yml
@@ -26,6 +26,8 @@ runcmd:
   - systemctl enable mysql
   - systemctl start mysql
   - bash /root/init-mysql.sh
+  - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
+  - chmod 0755 /usr/local/bin/waiter.sh
   - bash /usr/local/bin/waiter.sh readyz
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - bash /usr/local/bin/waiter.sh mysql
@@ -139,61 +141,7 @@ write_files:
     content: |
       #!/bin/bash
       # Script to do all the waiting
-      service="$1"
-      if [[ $service == "process-exporter" ]]; then
-        # process-exporter
-        while true; do
-          # Get the status of the process-exporter_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.process-exporter.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.process-exporter.service.consul." ]]; then
-            echo "process-exporter check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "process-exporter check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "mysql" ]]; then
-        # mysql
-        while true; do
-          # Get the status of the mysql_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.percona-xtradb-cluster.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.percona-xtradb-cluster.service.consul." ]]; then
-            echo "mysql check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "mysql check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "readyz" ]] ; then
-        # PMM readyz
-        while true; do
-          # Check for DNS :facepalm:
-          dnsstatus=$(dig pmm-server.${environment_name}.local A | awk '/A.*10.*$/ {print $1}')
-
-          if [[ $dnsstatus == "pmm-server.${environment_name}.local." ]]; then
-            echo "PMMreadyz_check_http DNS check is passing."
-
-            # Get the status of the PMMreadyz_check_http check
-            status=$(dig @127.0.0.1 -p 8600 pmmreadyz.service.consul SRV | awk '/SRV.*bastion.${environment_name}.local.$/ {print $1}')
-        
-            if [[ $status == "pmmreadyz.service.consul." ]]; then
-              echo "PMMreadyz_check_http check is passing."
-              exit 0  
-            fi
-          else
-            echo "PMMreadyz_check_http DNS check is not passing."
-          fi
-          # If the check is not passing, wait for a short interval and try again
-          echo "PMMreadyz_check_http check is not passing. Will retry in 1 second..."
-          sleep 1
-        done
-      fi
+      # File contents will be downloaded from githubcontent.com
   - path: /root/.my.cnf
     permissions: "0644"
     content: |

--- a/pmmdemo/provision_scripts/percona_xtradb_cluster_80.yml
+++ b/pmmdemo/provision_scripts/percona_xtradb_cluster_80.yml
@@ -28,12 +28,12 @@ runcmd:
   - bash /root/init-mysql.sh
   - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
   - chmod 0755 /usr/local/bin/waiter.sh
-  - bash /usr/local/bin/waiter.sh readyz
+  - bash /usr/local/bin/waiter.sh readyz ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - bash /usr/local/bin/waiter.sh mysql
   - pmm-admin add mysql --metrics-mode=push --username=pmm-admin --password='${mysql_root_password}' --cluster='pxc-80-cluster' --replication-set='pxc-80-cluster' --environment='prod' --query-source=slowlog --service-name="${name}-mysql"
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
-  - bash /usr/local/bin/waiter.sh process-exporter
+  - bash /usr/local/bin/waiter.sh process-exporter ${name} ${fqdn} ${environment_name}
   - pmm-admin add external --group=processes --listen-port=9256 --environment="prod" --service-name="${name}-processes" --cluster="processes-cluster"
 
 mounts:

--- a/pmmdemo/provision_scripts/pmm_server.yml
+++ b/pmmdemo/provision_scripts/pmm_server.yml
@@ -42,11 +42,11 @@ runcmd:
   - dnf -y install pmm-client
   - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
   - chmod 0755 /usr/local/bin/waiter.sh
-  - bash /usr/local/bin/waiter.sh readyz
+  - bash /usr/local/bin/waiter.sh readyz ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_admin_pass}@${pmm_server_endpoint}' ${fqdn} generic "${name}-host"
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
   - dnf -y install process-exporter_0.8.5_linux_amd64.rpm
-  - bash /usr/local/bin/waiter.sh process-exporter
+  - bash /usr/local/bin/waiter.sh process-exporter ${name} ${fqdn} ${environment_name}
   - pmm-admin add external --group=processes --listen-port=9256 --environment="prod" --service-name="${name}-processes" --cluster="processes-cluster"
   - bash /tmp/dashboard-importer.sh
 #  - bash /tmp/import-dashboard-grafana-cloud.sh && touch /tmp/dashboards_imported

--- a/pmmdemo/provision_scripts/pmm_server.yml
+++ b/pmmdemo/provision_scripts/pmm_server.yml
@@ -40,6 +40,8 @@ runcmd:
   - echo date > /tmp/pmm-server-up
   - percona-release setup -y pmm3-client
   - dnf -y install pmm-client
+  - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
+  - chmod 0755 /usr/local/bin/waiter.sh
   - bash /usr/local/bin/waiter.sh readyz
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_admin_pass}@${pmm_server_endpoint}' ${fqdn} generic "${name}-host"
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
@@ -122,61 +124,7 @@ write_files:
     content: |
       #!/bin/bash
       # Script to do all the waiting
-      service="$1"
-      if [[ $service == "process-exporter" ]]; then
-        # process-exporter
-        while true; do
-          # Get the status of the process-exporter_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.process-exporter.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.process-exporter.service.consul." ]]; then
-            echo "process-exporter check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "process-exporter check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "proxysql" ]]; then
-        # proxysql
-        while true; do
-          # Get the status of the Proxysql check
-          status=$(dig @127.0.0.1 -p 8600 proxysql.service.consul SRV | awk '/SRV.*proxysql.${environment_name}.local.$/ {print $1}')
-
-          if [[ $status == "proxysql.service.consul." ]]; then
-            echo "ProxySQL check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "ProxySQL check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "readyz" ]] ; then
-        # PMM readyz
-        while true; do
-          # Check for DNS :facepalm:
-          dnsstatus=$(dig pmm-server.${environment_name}.local A | awk '/A.*10.*$/ {print $1}')
-
-          if [[ $dnsstatus == "pmm-server.${environment_name}.local." ]]; then
-            echo "PMMreadyz_check_http DNS check is passing."
-
-            # Get the status of the PMMreadyz_check_http check
-            status=$(dig @127.0.0.1 -p 8600 pmmreadyz.service.consul SRV | awk '/SRV.*bastion.${environment_name}.local.$/ {print $1}')
-        
-            if [[ $status == "pmmreadyz.service.consul." ]]; then
-              echo "PMMreadyz_check_http check is passing."
-              exit 0  
-            fi
-          else
-            echo "PMMreadyz_check_http DNS check is not passing."
-          fi
-          # If the check is not passing, wait for a short interval and try again
-          echo "PMMreadyz_check_http check is not passing. Will retry in 1 second..."
-          sleep 1
-        done
-      fi
+      # File contents will be downloaded from githubcontent.com
   - path: /root/consul-advertise-addr.sh
     permissions: "0700"
     content: |

--- a/pmmdemo/provision_scripts/postgres_16.yml
+++ b/pmmdemo/provision_scripts/postgres_16.yml
@@ -24,7 +24,7 @@ runcmd:
   - dnf -y install pmm-client
   - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
   - chmod 0755 /usr/local/bin/waiter.sh
-  - bash /usr/local/bin/waiter.sh readyz
+  - bash /usr/local/bin/waiter.sh readyz ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - percona-release setup -y ppg-16
   - dnf -y install percona-postgresql16-server percona-pg-stat-monitor16
@@ -42,7 +42,7 @@ runcmd:
   - runuser -l postgres -c 'bash /tmp/init-postgres.sh'
   - pmm-admin add postgresql --username=pmm --password='${postgres_pmm_password}' --server-url='https://admin:${pmm_password}@${pmm_server_endpoint}' --server-insecure-tls --query-source="pgstatmonitor" --environment="prod" --service-name=${name}-postgresql --cluster="postgresql-cluster" --replication-set="${environment_name}"
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
-  - bash /usr/local/bin/waiter.sh process-exporter
+  - bash /usr/local/bin/waiter.sh process-exporter ${name} ${fqdn} ${environment_name}
   - pmm-admin add external --group=processes --listen-port=9256 --environment="prod" --service-name="${name}-processes" --cluster="processes-cluster"
 
 write_files:

--- a/pmmdemo/provision_scripts/postgres_16.yml
+++ b/pmmdemo/provision_scripts/postgres_16.yml
@@ -22,6 +22,8 @@ runcmd:
   - dnf -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm
   - percona-release setup -y pmm3-client
   - dnf -y install pmm-client
+  - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
+  - chmod 0755 /usr/local/bin/waiter.sh
   - bash /usr/local/bin/waiter.sh readyz
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - percona-release setup -y ppg-16
@@ -87,46 +89,7 @@ write_files:
     content: |
       #!/bin/bash
       # Script to do all the waiting
-      service="$1"
-      if [[ $service == "process-exporter" ]]; then
-        # process-exporter
-        while true; do
-          # Get the status of the process-exporter_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.process-exporter.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.process-exporter.service.consul." ]]; then
-            echo "process-exporter check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "process-exporter check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "readyz" ]] ; then
-        # PMM readyz
-        while true; do
-          # Check for DNS :facepalm:
-          dnsstatus=$(dig pmm-server.${environment_name}.local A | awk '/A.*10.*$/ {print $1}')
-
-          if [[ $dnsstatus == "pmm-server.${environment_name}.local." ]]; then
-            echo "PMMreadyz_check_http DNS check is passing."
-
-            # Get the status of the PMMreadyz_check_http check
-            status=$(dig @127.0.0.1 -p 8600 pmmreadyz.service.consul SRV | awk '/SRV.*bastion.${environment_name}.local.$/ {print $1}')
-        
-            if [[ $status == "pmmreadyz.service.consul." ]]; then
-              echo "PMMreadyz_check_http check is passing."
-              exit 0  
-            fi
-          else
-            echo "PMMreadyz_check_http DNS check is not passing."
-          fi
-          # If the check is not passing, wait for a short interval and try again
-          echo "PMMreadyz_check_http check is not passing. Will retry in 1 second..."
-          sleep 1
-        done
-      fi
+      # File contents will be downloaded from githubcontent.com
   - path: /tmp/init-postgres.sh
     content: |
       #!/bin/bash

--- a/pmmdemo/provision_scripts/proxysql_20.yml
+++ b/pmmdemo/provision_scripts/proxysql_20.yml
@@ -21,6 +21,8 @@ runcmd:
   - dnf -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm
   - percona-release setup -y pmm3-client
   - dnf -y install pmm-client
+  - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
+  - chmod 0755 /usr/local/bin/waiter.sh
   - bash /usr/local/bin/waiter.sh readyz
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_admin_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
@@ -156,61 +158,7 @@ write_files:
     content: |
       #!/bin/bash
       # Script to do all the waiting
-      service="$1"
-      if [[ $service == "process-exporter" ]]; then
-        # process-exporter
-        while true; do
-          # Get the status of the process-exporter_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.process-exporter.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.process-exporter.service.consul." ]]; then
-            echo "process-exporter check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "process-exporter check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "proxysql" ]]; then
-        # proxysql
-        while true; do
-          # Get the status of the Proxysql check
-          status=$(dig @127.0.0.1 -p 8600 proxysql.service.consul SRV | awk '/SRV.*proxysql.${environment_name}.local.$/ {print $1}')
-
-          if [[ $status == "proxysql.service.consul." ]]; then
-            echo "ProxySQL check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "ProxySQL check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "readyz" ]] ; then
-        # PMM readyz
-        while true; do
-          # Check for DNS :facepalm:
-          dnsstatus=$(dig pmm-server.${environment_name}.local A | awk '/A.*10.*$/ {print $1}')
-
-          if [[ $dnsstatus == "pmm-server.${environment_name}.local." ]]; then
-            echo "PMMreadyz_check_http DNS check is passing."
-
-            # Get the status of the PMMreadyz_check_http check
-            status=$(dig @127.0.0.1 -p 8600 pmmreadyz.service.consul SRV | awk '/SRV.*bastion.${environment_name}.local.$/ {print $1}')
-        
-            if [[ $status == "pmmreadyz.service.consul." ]]; then
-              echo "PMMreadyz_check_http check is passing."
-              exit 0  
-            fi
-          else
-            echo "PMMreadyz_check_http DNS check is not passing."
-          fi
-          # If the check is not passing, wait for a short interval and try again
-          echo "PMMreadyz_check_http check is not passing. Will retry in 1 second..."
-          sleep 1
-        done
-      fi
+      # File contents will be downloaded from githubcontent.com
   - path: /etc/proxysql.cnf
     content: |
       datadir="/var/lib/proxysql"

--- a/pmmdemo/provision_scripts/proxysql_20.yml
+++ b/pmmdemo/provision_scripts/proxysql_20.yml
@@ -23,16 +23,16 @@ runcmd:
   - dnf -y install pmm-client
   - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
   - chmod 0755 /usr/local/bin/waiter.sh
-  - bash /usr/local/bin/waiter.sh readyz
+  - bash /usr/local/bin/waiter.sh readyz ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_admin_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
-  - bash /usr/local/bin/waiter.sh process-exporter
+  - bash /usr/local/bin/waiter.sh process-exporter ${name} ${fqdn} ${environment_name}
   - pmm-admin add external --group=processes --listen-port=9256 --environment="prod" --service-name="${name}-processes" --cluster="processes-cluster"
   - percona-release setup -y ps-80
   - dnf -y install proxysql2 percona-server-client
   - systemctl start proxysql
   - systemctl enable proxysql
-  - bash /usr/local/bin/waiter.sh proxysql
+  - bash /usr/local/bin/waiter.sh proxysql ${name} ${fqdn} ${environment_name}
   - pmm-admin add proxysql --username=admin --password='${proxysql_admin_password}' --server-insecure-tls --server-url='https://admin:${pmm_admin_password}@${pmm_server_endpoint}' --cluster=proxysql-cluster "${name}" "127.0.0.1:6032"
 
 # TODO replace to admin-stats_credentials user

--- a/pmmdemo/provision_scripts/scripts/waiter.sh
+++ b/pmmdemo/provision_scripts/scripts/waiter.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Script to do all the waiting
+service="$1"
+if [[ $service == "process-exporter" ]]; then
+# process-exporter
+while true; do
+    # Get the status of the process-exporter_check_http check
+    status=$(dig @127.0.0.1 -p 8600 ${name}.process-exporter.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
+
+    if [[ $status == "${name}.process-exporter.service.consul." ]]; then
+    echo "process-exporter check is passing."
+    exit 0
+    fi
+
+    # If the check is not passing, wait for a short interval and try again
+    echo "process-exporter check is not passing. Will retry in 3 seconds..."
+    sleep 3
+done
+elif [[ $service == "proxysql" ]]; then
+# proxysql
+while true; do
+    # Get the status of the Proxysql check
+    status=$(dig @127.0.0.1 -p 8600 proxysql.service.consul SRV | awk '/SRV.*proxysql.${environment_name}.$/ {print $1}')
+
+    if [[ $status == "proxysql.service.consul." ]]; then
+    echo "ProxySQL check is passing."
+    exit 0
+    fi
+
+    # If the check is not passing, wait for a short interval and try again
+    echo "ProxySQL check is not passing. Will retry in 3 seconds..."
+    sleep 3
+done
+elif [[ $service == "readyz" ]] ; then
+# PMM readyz
+while true; do
+    # Check for DNS :facepalm:
+    dnsstatus=$(dig pmm-server.${environment_name}.local A | awk '/A.*10.*$/ {print $1}')
+
+    if [[ $dnsstatus == "pmm-server.${environment_name}.local." ]]; then
+    echo "PMMreadyz_check_http DNS check is passing."
+
+    # Get the status of the PMMreadyz_check_http check
+    status=$(dig @127.0.0.1 -p 8600 pmmreadyz.service.consul SRV | awk '/SRV.*bastion.${environment_name}.local.$/ {print $1}')
+
+    if [[ $status == "pmmreadyz.service.consul." ]]; then
+        echo "PMMreadyz_check_http check is passing."
+        exit 0  
+    fi
+    else
+    echo "PMMreadyz_check_http DNS check is not passing."
+    fi
+    # If the check is not passing, wait for a short interval and try again
+    echo "PMMreadyz_check_http check is not passing. Will retry in 1 second..."
+    sleep 1
+done
+fi

--- a/pmmdemo/provision_scripts/scripts/waiter.sh
+++ b/pmmdemo/provision_scripts/scripts/waiter.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 # Script to do all the waiting
-service="$1"
-if [[ $service == "process-exporter" ]]; then
+waiter="$1"
+name="$2"
+fqdn="$3"
+environment_name="$4"
+
+if [[ $waiter == "process-exporter" ]]; then
 # process-exporter
 while true; do
     # Get the status of the process-exporter_check_http check
@@ -16,7 +20,7 @@ while true; do
     echo "process-exporter check is not passing. Will retry in 3 seconds..."
     sleep 3
 done
-elif [[ $service == "proxysql" ]]; then
+elif [[ $waiter == "proxysql" ]]; then
 # proxysql
 while true; do
     # Get the status of the Proxysql check
@@ -31,7 +35,7 @@ while true; do
     echo "ProxySQL check is not passing. Will retry in 3 seconds..."
     sleep 3
 done
-elif [[ $service == "readyz" ]] ; then
+elif [[ $waiter == "readyz" ]] ; then
 # PMM readyz
 while true; do
     # Check for DNS :facepalm:

--- a/pmmdemo/provision_scripts/sysbench.yml
+++ b/pmmdemo/provision_scripts/sysbench.yml
@@ -53,11 +53,11 @@ runcmd:
   - systemctl start sysbench.postgres16
   - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
   - chmod 0755 /usr/local/bin/waiter.sh
-  - bash /usr/local/bin/waiter.sh readyz
+  - bash /usr/local/bin/waiter.sh readyz ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_admin_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - systemctl list-units sysbench.*.service | sed -E '1d;/^LOAD/,$d;s/ .*//g' > sysbench.services.txt
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
-  - bash /usr/local/bin/waiter.sh process-exporter
+  - bash /usr/local/bin/waiter.sh process-exporter ${name} ${fqdn} ${environment_name}
   - pmm-admin add external --group=processes --listen-port=9256 --environment="prod" --service-name="${name}-processes" --cluster="processes-cluster"
 
 write_files:

--- a/pmmdemo/provision_scripts/sysbench.yml
+++ b/pmmdemo/provision_scripts/sysbench.yml
@@ -51,6 +51,8 @@ runcmd:
   - systemctl start sysbench.haproxy.pxc80
   - systemctl start sysbench.haproxy.pgr84
   - systemctl start sysbench.postgres16
+  - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
+  - chmod 0755 /usr/local/bin/waiter.sh
   - bash /usr/local/bin/waiter.sh readyz
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_admin_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - systemctl list-units sysbench.*.service | sed -E '1d;/^LOAD/,$d;s/ .*//g' > sysbench.services.txt
@@ -120,39 +122,7 @@ write_files:
     content: |
       #!/bin/bash
       # Script to do all the waiting
-      service="$1"
-      if [[ $service == "process-exporter" ]]; then
-        # process-exporter
-        while true; do
-          # Get the status of the process-exporter_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.process-exporter.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.process-exporter.service.consul." ]]; then
-            echo "process-exporter check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "process-exporter check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "readyz" ]] ; then
-        while true; do
-          dnsstatus=$(dig pmm-server.${environment_name}.local A | awk '/A.*10.*$/ {print $1}')
-          if [[ $dnsstatus == "pmm-server.${environment_name}.local." ]]; then
-            echo "PMMreadyz_check_http DNS check is passing."
-            status=$(dig @127.0.0.1 -p 8600 pmmreadyz.service.consul SRV | awk '/SRV.*bastion.${environment_name}.local.$/ {print $1}')
-            if [[ $status == "pmmreadyz.service.consul." ]]; then
-              echo "PMMreadyz_check_http check is passing."
-              exit 0  
-            fi
-          else
-            echo "PMMreadyz_check_http DNS check is not passing."
-          fi
-          echo "PMMreadyz_check_http check is not passing. Will retry in 1 second..."
-          sleep 1
-        done
-      fi
+      # File contents will be downloaded from githubcontent.com
   - path: /etc/sysbench/exec_sysbench.sh
     content: |
       #!/bin/bash

--- a/pmmdemo/provision_scripts/valkey.yml
+++ b/pmmdemo/provision_scripts/valkey.yml
@@ -21,10 +21,10 @@ runcmd:
   - dnf -y install pmm-client
   - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
   - chmod 0755 /usr/local/bin/waiter.sh
-  - bash /usr/local/bin/waiter.sh readyz
+  - bash /usr/local/bin/waiter.sh readyz ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_admin_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
-  - bash /usr/local/bin/waiter.sh process-exporter
+  - bash /usr/local/bin/waiter.sh process-exporter ${name} ${fqdn} ${environment_name}
   - pmm-admin add external --group=processes --listen-port=9256 --environment="prod" --service-name="${name}-processes" --cluster="processes-cluster"
   - percona-release enable valkey experimental
   - dnf -y install valkey

--- a/pmmdemo/provision_scripts/valkey.yml
+++ b/pmmdemo/provision_scripts/valkey.yml
@@ -19,6 +19,8 @@ runcmd:
   - dnf -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm
   - percona-release setup -y pmm3-client
   - dnf -y install pmm-client
+  - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
+  - chmod 0755 /usr/local/bin/waiter.sh
   - bash /usr/local/bin/waiter.sh readyz
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_admin_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
@@ -148,62 +150,7 @@ write_files:
     content: |
       #!/bin/bash
       # Script to do all the waiting
-      service="$1"
-      if [[ $service == "process-exporter" ]]; then
-        # process-exporter
-        while true; do
-          # Get the status of the process-exporter_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.process-exporter.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.process-exporter.service.consul." ]]; then
-            echo "process-exporter check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "process-exporter check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "valkey-exporter" ]]; then
-        # valkey-exporter
-        while true; do
-          # Get the status of the valkey-exporter_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.valkey-exporter.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.valkey-exporter.service.consul." ]]; then
-            echo "valkey-exporter check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "valkey-exporter check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "readyz" ]] ; then
-        # PMM readyz
-        while true; do
-          # Check for DNS :facepalm:
-          dnsstatus=$(dig pmm-server.${environment_name}.local A | awk '/A.*10.*$/ {print $1}')
-
-          if [[ $dnsstatus == "pmm-server.${environment_name}.local." ]]; then
-            echo "PMMreadyz_check_http DNS check is passing."
-
-            # Get the status of the PMMreadyz_check_http check
-            status=$(dig @127.0.0.1 -p 8600 pmmreadyz.service.consul SRV | awk '/SRV.*bastion.${environment_name}.local.$/ {print $1}')
-        
-            if [[ $status == "pmmreadyz.service.consul." ]]; then
-              echo "PMMreadyz_check_http check is passing."
-              exit 0  
-            fi
-          else
-            echo "PMMreadyz_check_http DNS check is not passing."
-          fi
-          # If the check is not passing, wait for a short interval and try again
-          echo "PMMreadyz_check_http check is not passing. Will retry in 1 second..."
-          sleep 1
-        done
-      fi
-
+      # File contents will be downloaded from githubcontent.com
   - path: /etc/valkey/memtier-run.sh
     permissions: "0744"
     content: |

--- a/pmmdemo/provision_scripts/ycsb.yml
+++ b/pmmdemo/provision_scripts/ycsb.yml
@@ -19,6 +19,8 @@ runcmd:
   - dnf -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm
   - percona-release setup -y pmm3-client
   - dnf -y install pmm-client
+  - curl -s https://raw.githubusercontent.com/percona/pmm-infra/pmmdemo/provision_scripts/scripts/waiter.sh -o /usr/local/bin/waiter.sh
+  - chmod 0755 /usr/local/bin/waiter.sh
   - bash /usr/local/bin/waiter.sh readyz ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_admin_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
@@ -85,61 +87,7 @@ write_files:
     content: |
       #!/bin/bash
       # Script to do all the waiting
-      service="$1"
-      if [[ $service == "process-exporter" ]]; then
-        # process-exporter
-        while true; do
-          # Get the status of the process-exporter_check_http check
-          status=$(dig @127.0.0.1 -p 8600 ${name}.process-exporter.service.consul SRV | awk '/SRV.*${fqdn}\.$/ {print $1}')
-
-          if [[ $status == "${name}.process-exporter.service.consul." ]]; then
-            echo "process-exporter check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "process-exporter check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "proxysql" ]]; then
-        # proxysql
-        while true; do
-          # Get the status of the Proxysql check
-          status=$(dig @127.0.0.1 -p 8600 proxysql.service.consul SRV | awk '/SRV.*proxysql.${environment_name}.local.$/ {print $1}')
-
-          if [[ $status == "proxysql.service.consul." ]]; then
-            echo "ProxySQL check is passing."
-            exit 0
-          fi
-
-          # If the check is not passing, wait for a short interval and try again
-          echo "ProxySQL check is not passing. Will retry in 3 seconds..."
-          sleep 3
-        done
-      elif [[ $service == "readyz" ]] ; then
-        # PMM readyz
-        while true; do
-          # Check for DNS :facepalm:
-          dnsstatus=$(dig pmm-server.${environment_name}.local A | awk '/A.*10.*$/ {print $1}')
-
-          if [[ $dnsstatus == "pmm-server.${environment_name}.local." ]]; then
-            echo "PMMreadyz_check_http DNS check is passing."
-
-            # Get the status of the PMMreadyz_check_http check
-            status=$(dig @127.0.0.1 -p 8600 pmmreadyz.service.consul SRV | awk '/SRV.*bastion.${environment_name}.local.$/ {print $1}')
-        
-            if [[ $status == "pmmreadyz.service.consul." ]]; then
-              echo "PMMreadyz_check_http check is passing."
-              exit 0  
-            fi
-          else
-            echo "PMMreadyz_check_http DNS check is not passing."
-          fi
-          # If the check is not passing, wait for a short interval and try again
-          echo "PMMreadyz_check_http check is not passing. Will retry in 1 second..."
-          sleep 1
-        done
-      fi
+      # File contents will be downloaded from githubcontent.com
   - path: /etc/ycsb/shard.js
     content: |
       sh.enableSharding('ycsb');

--- a/pmmdemo/provision_scripts/ycsb.yml
+++ b/pmmdemo/provision_scripts/ycsb.yml
@@ -19,10 +19,10 @@ runcmd:
   - dnf -y install https://repo.percona.com/yum/percona-release-latest.noarch.rpm
   - percona-release setup -y pmm3-client
   - dnf -y install pmm-client
-  - bash /usr/local/bin/waiter.sh readyz
+  - bash /usr/local/bin/waiter.sh readyz ${name} ${fqdn} ${environment_name}
   - pmm-admin config --az="us-east-1f" --region="us-east-1" --metrics-mode=push --force --server-insecure-tls --server-url='https://admin:${pmm_admin_password}@${pmm_server_endpoint}' ${fqdn} generic ${name}
   - dnf -y install https://github.com/ncabatoff/process-exporter/releases/download/v0.8.5/process-exporter_0.8.5_linux_amd64.rpm
-  - bash /usr/local/bin/waiter.sh process-exporter
+  - bash /usr/local/bin/waiter.sh process-exporter ${name} ${fqdn} ${environment_name}
   - pmm-admin add external --group=processes --listen-port=9256 --environment="prod" --service-name="${name}-processes" --cluster="processes-cluster"
   - percona-release setup -y psmdb-60
   - dnf -y install python2 java-1.8.0-openjdk percona-server-mongodb


### PR DESCRIPTION
This PR moves the waiter.sh from a write_files in each provision_scripts/*.yml to a curl from githubcontent. So we reduce the size of our build by several hundred characters,staying below the 16k limit imposed by AWS.